### PR TITLE
docs: improve usage description with docker compose and jar run instructions

### DIFF
--- a/src/docs/asciidoc/appendix.adoc
+++ b/src/docs/asciidoc/appendix.adoc
@@ -116,6 +116,114 @@ _For, clarity, here is how an encore-setting configuration with audio-mix-preset
 ----
 include::https://raw.githubusercontent.com/svt/encore-doc/main/src/docs/asciidoc/examples/configuration/application-prod.yml[]
 ----
+
+
+
+[[running_encore]]
+=== Running Encore
+
+As a complement to the UserGuide, here is a few more examples on how you can try out **Encore**.
+
+* Using Docker-Compose
+* Using Spring Boot BootRun
+* Building an Docker Image and run Encore in a Docker Container
+
+
+==== Example: using Docker Compose
+
+* This step requires:
+** https://docs.docker.com/compose/install/Docker-compose[Docker Compose]
+
+
+- Use a docker-compose.yml
+
+[source,yaml]
+....
+include::examples/docker/docker-compose.yml[]
+....
+
+and then
+
+Linux
+[source,console]
+....
+$ ./docker-compose up
+....
+
+Mac
+[source,console]
+....
+$ ./docker compose up
+....
+
+and you should see Encore starting up.
+
+IMPORTANT: By default, there are two folders mapped to your host system by using the example docker-compose file. 
+**/tmp/input and /tmp/output**, which we will refer to as the **inputdir** and the **outputdir**
+_Change these (in the docker-compose file) to something that suits your environment if you are not running on Linux. 
+For example /Users/<YOURUSER>/input:/tmp/input should be fine on macos._
+
+===== Get the IP
+
+On Linux:
+- To find the IP Docker-Compose creates (so that you can access Encore's api).
+
+
+[source,console]
+....
+$ docker inspect <nameOfDirectoryYouAreRunningFrom>_encorenet
+....
+
+NOTE: By design Docker-compose creates a network called <nameOfDirectoryYouAreRunningFrom>_encorenet
+
+On macos:
+Use 'localhost'
+
+Got the IP? - great! Continue to <<posting-your-first-encorejob>>
+
+==== Example: run Encore with Spring Boot bootRun
+
+You can run *Encore* on your local machine by starting up a local developer Application Profile:
+
+.In the *Encore* root folder:
+[source,bash]
+----
+foobar@foo:~$ SPRING_PROFILES_ACTIVE=local ./gradlew clean bootRun
+----
+
+NOTE: This will use the _src/main/resources/application-local.yml_ configuration profile in *Encore*.
+
+If the startup fails, verify that you are fulfilling the <<requirements-run-local-boot,requirements>>
+
+Continue to <<posting-your-first-encorejob>>
+
+==== Example: run Encore in a Docker Image
+
+- Create or find a base FFmpeg/Mediainfo Docker image.
+
+The given example installs a recent version of FFmpeg, with a few FFmpeg filters, and mediainfo.
+Modify as needed, using a tap of https://docs.brew.sh/Homebrew-on-Linux[Homebrew] as an installation base.
+
+.A FFmpeg Dockerfile example (click to expand)
+[%collapsible]
+====
+[source,dockerfile]
+----
+include::examples/docker/FFmpegDockerfile[]
+----
+
+====
+
+.With the environment variable DOCKER_BASE_IMAGE pointing to your FFmpeg Docker Image
+[source,bash]
+----
+foobar@foo:~$ docker build -t encore-docker --build-arg DOCKER_BASE_IMAGE=<yourdockerbaseimage:youjustbuilt> . 
+
+foobar@foo:~$ docker run --network=host -v /tmp/input:/tmp/input -v /tmp/output:/tmp/output -e SPRING_PROFILES_ACTIVE='local' encore-docker
+----
+
+Continue to <<posting-your-first-encorejob>>
+
 === Homebrew AVTools
 
 So you noticed that the FFmpeg Docker Example in the quickstart used the Repository Manager Brew?

--- a/src/docs/asciidoc/appendix.adoc
+++ b/src/docs/asciidoc/appendix.adoc
@@ -110,6 +110,7 @@ Beside the rich configuration possibilities of https://docs.spring.io/spring-boo
 _For, clarity, here is how an encore-setting configuration with audio-mix-presets could look like in real life._
 
 
+[[configurationexample]]
 .encore-settings configuration example
 [source, yaml]
 ----

--- a/src/docs/asciidoc/communityguide.adoc
+++ b/src/docs/asciidoc/communityguide.adoc
@@ -32,6 +32,13 @@ Currently, there are no extensions interface endpoints, but you could, for examp
 
 Also, open a discussion issue if you have any ideas regarding contributions about extensions to *Encore* that you want to discuss.
 
+
+==== How can I create a profile doing X?
+
+Have a look at a few profiles from the documentation or project test examples to learn how you can set different options.
+Also, see if you can do what you can do what you want with pure FFmpeg.
+It should then be doable to map that configuration to a custom profile.
+
 === Articles and talks
 
 https://medium.com/the-svt-tech-blog/encore-open-source-licensed-to-once-again-transcode-bbf854f7a812[Article: 2021 - Encore - licensed to once again transcode]
@@ -42,6 +49,10 @@ https://conf.tube/videos/watch/751d41f4-72fd-4bfe-aa26-8d8b0e8054c2[Video: 2019 
 
 https://medium.com/the-svt-tech-blog/encore-video-transcoding-at-its-core-b80c3e5658b3[Article: 2018 Encore - video transcoding at it's core]
 - while interesting for the project origins, it contains partially *non-valid information* as the code has been largely rewritten since then.
+
+=== Third-party extensions
+
+Eyevinn IAF plugin: https://dev.to/video/locally-transcode-vod-content-with-eyevinn-ingest-application-framework-and-svt-encore-2md7IAF[An IAF plugin for SVT Encore]
 
 === Support
 

--- a/src/docs/asciidoc/examples/docker/docker-compose.yml
+++ b/src/docs/asciidoc/examples/docker/docker-compose.yml
@@ -7,13 +7,13 @@ services:
     - encorenet 
 
   encore:
-    image: ghcr.io/janderssonse/encore-debian:latest
+    image: ghcr.io/svt/encore-debian:latest
     depends_on:
       - redis
     environment:
       - SPRING_PROFILES_ACTIVE=local
       - SPRING_REDIS_HOST=redis
-      - PROFILE_LOCATION=url:https://raw.githubusercontent.com/janderssonse/encore-doc/improvequickstart/src/docs/asciidoc/examples/profile/profiles.yml
+      - PROFILE_LOCATION=url:https://raw.githubusercontent.com/svt/encore-doc/main/src/docs/asciidoc/examples/profile/profiles.yml
 
     ports:
       - "8080:8080"

--- a/src/docs/asciidoc/examples/docker/docker-compose.yml
+++ b/src/docs/asciidoc/examples/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+
+services:
+  redis:
+    image: redis:alpine
+    networks:
+    - encorenet 
+
+  encore:
+    image: ghcr.io/janderssonse/encore-debian:latest
+    depends_on:
+      - redis
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - SPRING_REDIS_HOST=redis
+      - PROFILE_LOCATION=url:https://raw.githubusercontent.com/janderssonse/encore-doc/improvequickstart/src/docs/asciidoc/examples/profile/profiles.yml
+
+    ports:
+      - "8080:8080"
+    volumes:
+      - /tmp/input:/tmp/input:rw # where your put your source files
+      - /tmp/output:/tmp/output:rw #put your output here
+    networks:
+    - encorenet 
+
+networks:
+ encorenet:
+   driver: bridge

--- a/src/docs/asciidoc/examples/profile/video.yml
+++ b/src/docs/asciidoc/examples/profile/video.yml
@@ -23,5 +23,6 @@ encodes:
       ref: 8
     audioEncode:
       type: AudioEncode
+      codec: aac
       bitrate: 256k
       suffix: STEREO

--- a/src/docs/asciidoc/examples/profile/withforcekeyframe.yml
+++ b/src/docs/asciidoc/examples/profile/withforcekeyframe.yml
@@ -159,10 +159,5 @@ encodes:
     skipIfNoAudioMixPreset: true
     params:
       cutoff: 14000
-  - type: AudioEncode
-    codec: ac3
-    bitrate: 448k
-    suffix: SURROUND
-    channels: 6
   - type: ThumbnailMapEncode
   - type: ThumbnailEncode

--- a/src/docs/asciidoc/examples/profile/withforcekeyframe.yml
+++ b/src/docs/asciidoc/examples/profile/withforcekeyframe.yml
@@ -165,4 +165,4 @@ encodes:
     suffix: SURROUND
     channels: 6
   - type: ThumbnailMapEncode
-  - type: ThumbnailEncode (edited) 
+  - type: ThumbnailEncode

--- a/src/docs/asciidoc/examples/profile/withforcekeyframe.yml
+++ b/src/docs/asciidoc/examples/profile/withforcekeyframe.yml
@@ -143,21 +143,5 @@ encodes:
     suffix: STEREO_LB
     params:
       cutoff: 14000
-  - type: AudioEncode
-    codec: aac
-    bitrate: 192k
-    suffix: STEREO_DE
-    audioMixPreset: de
-    skipIfNoAudioMixPreset: true
-    params:
-      cutoff: 20000
-  - type: AudioEncode
-    codec: aac
-    bitrate: 64k
-    suffix: STEREO_DELB
-    audioMixPreset: de
-    skipIfNoAudioMixPreset: true
-    params:
-      cutoff: 14000
   - type: ThumbnailMapEncode
   - type: ThumbnailEncode

--- a/src/docs/asciidoc/examples/profile/withforcekeyframe.yml
+++ b/src/docs/asciidoc/examples/profile/withforcekeyframe.yml
@@ -25,6 +25,7 @@ encodes:
       ref: 4
     audioEncode:
       type: AudioEncode
+      codec: aac
       bitrate: 192k
       suffix: STEREO
   - type: X264Encode
@@ -50,6 +51,7 @@ encodes:
       ref: 4
     audioEncode:
       type: AudioEncode
+      codec: aac
       bitrate: 128k
       suffix: STEREO
   - type: X264Encode
@@ -75,6 +77,7 @@ encodes:
       ref: 4
     audioEncode:
       type: AudioEncode
+      codec: aac
       bitrate: 96k
       suffix: STEREO
   - type: X264Encode
@@ -100,6 +103,7 @@ encodes:
       ref: 4
     audioEncode:
       type: AudioEncode
+      codec: aac
       bitrate: 96k
       suffix: STEREO
   - type: X264Encode
@@ -124,19 +128,23 @@ encodes:
       ref: 3
     audioEncode:
       type: AudioEncode
+      codec: aac
       bitrate: 96k
       suffix: STEREO
   - type: AudioEncode
+    codec: aac
     bitrate: 192k
     suffix: STEREO
     params:
       cutoff: 20000
   - type: AudioEncode
+    codec: aac
     bitrate: 64k
     suffix: STEREO_LB
     params:
       cutoff: 14000
   - type: AudioEncode
+    codec: aac
     bitrate: 192k
     suffix: STEREO_DE
     audioMixPreset: de
@@ -144,6 +152,7 @@ encodes:
     params:
       cutoff: 20000
   - type: AudioEncode
+    codec: aac
     bitrate: 64k
     suffix: STEREO_DELB
     audioMixPreset: de

--- a/src/docs/asciidoc/technicalguide.adoc
+++ b/src/docs/asciidoc/technicalguide.adoc
@@ -94,7 +94,7 @@ This will happen when the project is mature.
 ==== Encore Job
 
 The Encore Job is a central object in Encore.
-The Encore Job fields are described in the <<dynamically-generated-endpoint-documentation>>, but also in the
+The Encore Job fields are described in the <<dynamicapiendpoints>>, but also in the
 
 xref:openapi.adoc#_encorejob[EncoreJob static documentation]
 

--- a/src/docs/asciidoc/userguide.adoc
+++ b/src/docs/asciidoc/userguide.adoc
@@ -1,6 +1,8 @@
 == The User Guide
 
-This part of the documentation describes how to build the project, a gives a few examples of how you can try-it-out locally.
+This part of the documentation describes how to build the project, and/or just use the pre-built jar to run it directly.
+
+NOTE: The <<running_encore,appendix>> gives a few other examples of how you can run Encore
 
 === Building the project
 
@@ -11,7 +13,6 @@ _Note: This step is not needed if you are trying out Encore with the_ <<example-
 ** JDK 11 or later
 ** An available Redis instance (default configuration: locally installed port 6379)
 ** FFmpeg and Mediainfo (we recommend the versions present in https://github.com/svt/homebrew-avtools[Homebrew-AVTools] repository, which has been tested to work with Encore).
-
 
 To build **Encore**, with all tests, do:
 
@@ -25,108 +26,21 @@ $ ./gradlew clean build
 $ ./gradlew clean build -x test
 ....
 
-=== Try-it-out examples
+=== Run Encore as a runnable jar
 
-A few examples on how you can try out **Encore**.
+You can run *Encore* on your local machine by starting up a local developer Application Profile.
+Get the https://github.com/svt/encore/release[pre-built encore jar], or first <<building-the-project,build the project>> and get the jar from ./build/libs/ 
 
-* Using Docker-Compose
-* Using Spring Boot BootRun 
-* Building an Docker Image and run Encore in a Docker Container
-
-==== Example: using Docker Compose
-
-* This step requires:
-** https://docs.docker.com/compose/install/Docker-compose[Docker Compose]
-
-
-- Use a docker-compose.yml
-
-[source,yaml]
-....
-include::examples/docker/docker-compose.yml[]
-....
-
-and then
-
-Linux
-[source,console]
-....
-$ ./docker-compose up
-....
-
-Mac
-[source,console]
-....
-$ ./docker compose up
-....
-
-and you should see Encore starting up.
-
-IMPORTANT: By default, there are two folders mapped to your host system by using the example docker-compose file. 
-**/tmp/input and /tmp/output**, which we will refer to as the **inputdir** and the **outputdir**
-_Change these (in the docker-compose file) to something that suits your environment if you are not running on Linux. 
-For example /Users/<YOURUSER>/input:/tmp/input should be fine on macos._
-
-====== Get the IP
-
-On Linux:
-- To find the IP Docker-Compose creates (so that you can access Encore's api).
-
-
-[source,console]
-....
-$ docker inspect <nameOfDirectoryYouAreRunningFrom>_encorenet
-....
-
-NOTE: By design Docker-compose creates a network called <nameOfDirectoryYouAreRunningFrom>_encorenet
-
-On macos:
-Use 'localhost'
-
-Got the IP? - great! Continue to <<posting-your-first-encorejob>>
-
-==== Example: run Encore with Spring Boot bootRun
-
-You can run *Encore* on your local machine by starting up a local developer Application Profile:
-
-.In the *Encore* root folder:
 [source,bash]
 ----
-foobar@foo:~$ SPRING_PROFILES_ACTIVE=local ./gradlew clean bootRun
+foobar@foo:~$ SPRING_PROFILES_ACTIVE=local java -jar encore-x.y.z.jar
 ----
 
 NOTE: This will use the _src/main/resources/application-local.yml_ configuration profile in *Encore*.
 
 If the startup fails, verify that you are fulfilling the <<requirements-run-local-boot,requirements>>
 
-Continue to <<posting-your-first-encorejob>>
-
-==== Example: run Encore in a Docker Image
-
-- Create or find a base FFmpeg/Mediainfo Docker image.
-
-The given example installs a recent version of FFmpeg, with a few FFmpeg filters, and mediainfo.
-Modify as needed, using a tap of https://docs.brew.sh/Homebrew-on-Linux[Homebrew] as an installation base.
-
-.A FFmpeg Dockerfile example (click to expand)
-[%collapsible]
-====
-[source,dockerfile]
-----
-include::examples/docker/FFmpegDockerfile[]
-----
-
-====
-
-.With the environment variable DOCKER_BASE_IMAGE pointing to your FFmpeg Docker Image
-[source,bash]
-----
-foobar@foo:~$ docker build -t encore-docker --build-arg DOCKER_BASE_IMAGE=<yourdockerbaseimage:youjustbuilt> . 
-
-foobar@foo:~$ docker run --network=host -v /tmp/input:/tmp/input -v /tmp/output:/tmp/output -e SPRING_PROFILES_ACTIVE='local' encore-docker
-----
-
-Continue to <<posting-your-first-encorejob>>
+Next, Continue to <<posting-your-first-encorejob>>
 
 === Posting your first EncoreJob
 

--- a/src/docs/asciidoc/userguide.adoc
+++ b/src/docs/asciidoc/userguide.adoc
@@ -1,141 +1,81 @@
 == The User Guide
 
-This part of the documentation describes how to get going with a quick start and installation hints.
+This part of the documentation describes how to build the project, a gives a few examples of how you can try-it-out locally.
 
-=== Usage
+=== Building the project
 
-==== Quicktest - do an encoding with Docker Compose
-
-This is for you who would like to just take Encore for a quick test, probally locally
-
-WARN: THIS way is not recommended or intended for any production use. **Don't**
-
-It will let you start encoding files, and later lets you dig into the details with an installation of you options. 
-
-* This step requires:
-** Docker-compose installed on your machine.
-
-1. Save this in a file in called docker-compose.yml
-TO-DO
-
-In the project root do:
-
-[source,console]
-....
-$ ./docker-compose up
-....
-
-and hopefully you should see Encore starting up without errors.
-
-IMPORTANT: There are two folders mapped to your host system by using the default docker-compose file. 
-**/tmp/input and /tmp/output.**, from now called **inputdir** **outputdir**
-_Change these (in the docker-compose file) to anything else if you run on a operating system not having the /tmp-folder, or prefer something else_.
-
- 
-2. Take a test mp4 file, and put in into your **inputdir** folder.
-You might have to change access permissions on the **inputdir** and **outputdir**. You need at least write access to the *inputdir** 
-In this example, we use one of the files from the test resources in the Encore project - let's copy this to **inputdir**:
-
-[source,console]
-....
-$ cp src/test/resources/input/test.mp4 /tmp/input
-....
-
-3. Before you post a job to Encore, you need to know the IP of the Docker-Compose created network first. Localhost wont work here.
-
-Show all networks docker-compose created. You are looing for one with <nameOfFolderYouAreRunningFrom>_default
-
-[source,console]
-....
-$ docker network list 
-....
-
-and to see the IP Docker is using
-
-[source,console]
-....
-$ docker inspect <nameOfFolderYouAreRunningFrom>_default
-....
-
-Got it - great!
-
-4. Now, fire up a browser and go to the http://<THE_DOCKER_IP>:8082/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/encorejob/postCollectionResource-encorejob-post - i.e directly to the Encore Swagger Interface for Posting an EncoreJob.
-
-
-5. Finally, push the try it out button and try with this example
-
-
-[source,json]
-....
-{
-	"id": "850e9058-4ec0-42ee-8fcc-fe974d50abc5",
-	"externalId": "externalId",
-	"profile": "program",
-	"outputFolder": "/tmp/output",
-	"baseName": "test",
-	"progressCallbackUri": "",
-	"priority": 0,
-	"message": null,
-	"progress": 0,
-	"speed": null,
-	"startedDate": null,
-	"completedDate": null,
-	"debugOverlay": true,
-	"logContext": {
-		"FlowId": "00a021f6-f285-4ae6-8b45-0aa0f67f42a4"
-	},
-	"seekTo": null,
-	"duration": null,
-	"thumbnailTime": null,
-	"inputs": [{
-		"uri": "/tmp/test.mp4",
-		"videoLabel": "main",
-		"audioLabel": "main",
-		"params": {},
-		"dar": null,
-		"useFirstAudioStreams": 2,
-		"cropTo": null,
-		"padTo": null,
-		"videoFilters": [],
-		"audioFilters": [],
-		"analyzed": null,
-		"videoStream": null,
-		"audioStream": null,
-		"probeInterlaced": true,
-		"type": "AudioVideo"
-	}],
-	"output": [],
-	"status": "NEW"
-}
-....
-
-You can now see some output in the terminal, and after a while you should see a couple of encoded files in the output dir. 
-Congratulations, you did your first encoding with Encore!
-
-==== Quickstart - build with gradle
-
-
-* This step requires:
+_Note: This step is not needed if you are trying out Encore with the_ <<example-using-docker-compose,Docker Compose example>>.
 
 [#requirements-run-local-boot]
-* Encore requires:
+* Requires:
 ** JDK 11 or later
 ** An available Redis instance (default configuration: locally installed port 6379)
-** FFmpeg (we recommend the version present in https://github.com/svt/homebrew-avtools[Homebrew-AVTools] repository, which is what we use in our production environment)
+** FFmpeg and Mediainfo (we recommend the versions present in https://github.com/svt/homebrew-avtools[Homebrew-AVTools] repository, which has been tested to work with Encore).
 
 
-===== Build the project
-
-Run all tests and static analysis using:
+To build **Encore**, with all tests, do:
 
 [source,bash]
 ....
 $ ./gradlew clean build
 ....
 
-===== Option - Quick Test Trial: Run a local version with Spring Boot bootRun
+[source,bash]
+....
+$ ./gradlew clean build -x test
+....
 
-You can run *Encore* on your local developer machine for a quick test trial by starting up a local developer Application Profile:
+=== Try-it-out examples
+
+A few examples on how you can try out **Encore**.
+
+* Using Docker-Compose
+* Using Spring Boot BootRun 
+* Building an Docker Image and run Encore in a Docker Container
+
+==== Example: using Docker Compose
+
+* This step requires:
+** https://docs.docker.com/compose/install/Docker-compose[Docker Compose]
+
+
+- Use a docker-compose.yml
+
+[source,yaml]
+....
+include::examples/docker/docker-compose.yml[]
+....
+
+and then
+
+[source,console]
+....
+$ ./docker-compose up
+....
+
+and you should see Encore starting up.
+
+IMPORTANT: By default, there are two folders mapped to your host system by using the example docker-compose file. 
+**/tmp/input and /tmp/output**, which we will refer to as the **inputdir** and the **outputdir**
+_Change these (in the docker-compose file) to something that suits your environment. 
+The default should be fine on mac/linux._
+
+- To find the IP Docker-Compose creates (so that you can access Encore's api).
+
+
+[source,console]
+....
+$ docker inspect <nameOfDirectoryYouAreRunningFrom>_encorenet
+....
+
+NOTE: By design Docker-compose creates a network called <nameOfDirectoryYouAreRunningFrom>_encorenet
+
+
+Got the IP? - great! Continue to <<posting-your-first-encorejob>>
+
+==== Example: run Encore with Spring Boot bootRun
+
+You can run *Encore* on your local machine by starting up a local developer Application Profile:
 
 .In the *Encore* root folder:
 [source,bash]
@@ -147,19 +87,16 @@ NOTE: This will use the _src/main/resources/application-local.yml_ configuration
 
 If the startup fails, verify that you are fulfilling the <<requirements-run-local-boot,requirements>>
 
-Otherwise, verify that you can see the OpenAPI3 Swagger Gui in your browser, see <<dynamicapiendpoints>>.
+Continue to <<posting-your-first-encorejob>>
 
-Success?? Great - you might want to check out the <<concepts>> next.
+==== Example: run Encore in a Docker Image
 
-===== Option - Docker Image: Run Encore in a Docker Image you build yourself
+- Create or find a base FFmpeg/Mediainfo Docker image.
 
-This quickstart option will show you how to use https://docs.brew.sh/Homebrew-on-Linux[Homebrew] and create an FFmpeg Docker Image to run Encore from.
+The given example installs a recent version of FFmpeg, with a few FFmpeg filters, and mediainfo.
+Modify as needed, using a tap of https://docs.brew.sh/Homebrew-on-Linux[Homebrew] as an installation base.
 
-First, you need to create a base FFmpeg Docker image.
-The following skeleton example installs a recent version of FFmpeg, with a few FFmpeg filters, and mediainfo.
-Modify as needed.
-
-.An FFmpeg Dockerfile example (click to expand)
+.A FFmpeg Dockerfile example (click to expand)
 [%collapsible]
 ====
 [source,dockerfile]
@@ -169,16 +106,54 @@ include::examples/docker/FFmpegDockerfile[]
 
 ====
 
-.With env variable DOCKER_BASE_IMAGE pointing to your FFmpeg Docker Image
+.With the environment variable DOCKER_BASE_IMAGE pointing to your FFmpeg Docker Image
 [source,bash]
 ----
-foobar@foo:~$ docker build -t encore-docker --build-arg DOCKER_BASE_IMAGE=<yourdockerbaseimage:youjustbuiltfromexample> . 
+foobar@foo:~$ docker build -t encore-docker --build-arg DOCKER_BASE_IMAGE=<yourdockerbaseimage:youjustbuilt> . 
 
-foobar@foo:~$ docker run --network=host -e SPRING_PROFILES_ACTIVE='local' encore-docker
+foobar@foo:~$ docker run --network=host -v /tmp/input:/tmp/input -v /tmp/output:/tmp/output -e SPRING_PROFILES_ACTIVE='local' encore-docker
 ----
 
-Verify that you can see the OpenAPI3 Swagger Gui in your browser, see <<dynamicapiendpoints>>.
+Continue to <<posting-your-first-encorejob>>
 
-Success?? Great - you might want to check out the <<concepts>> next.
+=== Posting your first EncoreJob
+
+* This step requires:
+** A running instance of Encore
+** A inputdir - where you put source files
+** A outputdir - where you want the encoded files to end up
 
 
+1) Use one of the files from the test resources in the Encore project and copy this to your **inputdir**
+(Verify that you have access permissions to the **inputdir** and **outputdir**.)
+
+[source,console]
+....
+$ cp src/test/resources/input/test.mp4 /tmp/input
+....
+
+2) Fire up a browser and http://<ENCORE_IP>:8080/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/ - i.e directly to the Encore Swagger Interface for Posting an EncoreJob.
+
+3) Finally, Under POST, hit the "Try it out" button and POST this example. 
+(Replace the *outputFolder* and *uri* with your **outputdir** and **inputdir**/filename.)
+
+
+[source,json]
+....
+
+  {
+  	"profile": "program",
+  	"outputFolder": "/tmp/output",
+  	"baseName": "quicktest_",
+  	"inputs": [{
+  		"uri": "/tmp/input/test.mp4",
+  		"useFirstAudioStreams": 2,
+  		"type": "AudioVideo"
+  	}]
+  }
+....
+
+You can now see some output in your terminal, and after a while you should see a couple of encoded files in the **outputdir**. 
+Congratulations, you did your first encoding with Encore!
+
+Now, find out more about specific options, see <<dynamicapiendpoints>>, or see the <<concepts>>.

--- a/src/docs/asciidoc/userguide.adoc
+++ b/src/docs/asciidoc/userguide.adoc
@@ -2,11 +2,120 @@
 
 This part of the documentation describes how to get going with a quick start and installation hints.
 
-=== Installation
+=== Usage
 
-Currently, there are no *pre-ready-to-go* installation packages, pods, docker images offered for *Encore*, but fear not - there are a few possibilities in how to get going. Continue reading!
+==== Quicktest - do an encoding with Docker Compose
 
-==== Quickstart
+This is for you who would like to just take Encore for a quick test, probally locally
+
+WARN: THIS way is not recommended or intended for any production use. **Don't**
+
+It will let you start encoding files, and later lets you dig into the details with an installation of you options. 
+
+* This step requires:
+** Docker-compose installed on your machine.
+
+1. Save this in a file in called docker-compose.yml
+TO-DO
+
+In the project root do:
+
+[source,console]
+....
+$ ./docker-compose up
+....
+
+and hopefully you should see Encore starting up without errors.
+
+IMPORTANT: There are two folders mapped to your host system by using the default docker-compose file. 
+**/tmp/input and /tmp/output.**, from now called **inputdir** **outputdir**
+_Change these (in the docker-compose file) to anything else if you run on a operating system not having the /tmp-folder, or prefer something else_.
+
+ 
+2. Take a test mp4 file, and put in into your **inputdir** folder.
+You might have to change access permissions on the **inputdir** and **outputdir**. You need at least write access to the *inputdir** 
+In this example, we use one of the files from the test resources in the Encore project - let's copy this to **inputdir**:
+
+[source,console]
+....
+$ cp src/test/resources/input/test.mp4 /tmp/input
+....
+
+3. Before you post a job to Encore, you need to know the IP of the Docker-Compose created network first. Localhost wont work here.
+
+Show all networks docker-compose created. You are looing for one with <nameOfFolderYouAreRunningFrom>_default
+
+[source,console]
+....
+$ docker network list 
+....
+
+and to see the IP Docker is using
+
+[source,console]
+....
+$ docker inspect <nameOfFolderYouAreRunningFrom>_default
+....
+
+Got it - great!
+
+4. Now, fire up a browser and go to the http://<THE_DOCKER_IP>:8082/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/encorejob/postCollectionResource-encorejob-post - i.e directly to the Encore Swagger Interface for Posting an EncoreJob.
+
+
+5. Finally, push the try it out button and try with this example
+
+
+[source,json]
+....
+{
+	"id": "850e9058-4ec0-42ee-8fcc-fe974d50abc5",
+	"externalId": "externalId",
+	"profile": "program",
+	"outputFolder": "/tmp/output",
+	"baseName": "test",
+	"progressCallbackUri": "",
+	"priority": 0,
+	"message": null,
+	"progress": 0,
+	"speed": null,
+	"startedDate": null,
+	"completedDate": null,
+	"debugOverlay": true,
+	"logContext": {
+		"FlowId": "00a021f6-f285-4ae6-8b45-0aa0f67f42a4"
+	},
+	"seekTo": null,
+	"duration": null,
+	"thumbnailTime": null,
+	"inputs": [{
+		"uri": "/tmp/test.mp4",
+		"videoLabel": "main",
+		"audioLabel": "main",
+		"params": {},
+		"dar": null,
+		"useFirstAudioStreams": 2,
+		"cropTo": null,
+		"padTo": null,
+		"videoFilters": [],
+		"audioFilters": [],
+		"analyzed": null,
+		"videoStream": null,
+		"audioStream": null,
+		"probeInterlaced": true,
+		"type": "AudioVideo"
+	}],
+	"output": [],
+	"status": "NEW"
+}
+....
+
+You can now see some output in the terminal, and after a while you should see a couple of encoded files in the output dir. 
+Congratulations, you did your first encoding with Encore!
+
+==== Quickstart - build with gradle
+
+
+* This step requires:
 
 [#requirements-run-local-boot]
 * Encore requires:
@@ -14,13 +123,14 @@ Currently, there are no *pre-ready-to-go* installation packages, pods, docker im
 ** An available Redis instance (default configuration: locally installed port 6379)
 ** FFmpeg (we recommend the version present in https://github.com/svt/homebrew-avtools[Homebrew-AVTools] repository, which is what we use in our production environment)
 
+
 ===== Build the project
 
 Run all tests and static analysis using:
 
 [source,bash]
 ....
-$ ./gradlew clean check
+$ ./gradlew clean build
 ....
 
 ===== Option - Quick Test Trial: Run a local version with Spring Boot bootRun
@@ -41,7 +151,7 @@ Otherwise, verify that you can see the OpenAPI3 Swagger Gui in your browser, see
 
 Success?? Great - you might want to check out the <<concepts>> next.
 
-===== Option - Docker Image: Run Encore in a Docker Image
+===== Option - Docker Image: Run Encore in a Docker Image you build yourself
 
 This quickstart option will show you how to use https://docs.brew.sh/Homebrew-on-Linux[Homebrew] and create an FFmpeg Docker Image to run Encore from.
 

--- a/src/docs/asciidoc/userguide.adoc
+++ b/src/docs/asciidoc/userguide.adoc
@@ -48,18 +48,28 @@ include::examples/docker/docker-compose.yml[]
 
 and then
 
+Linux
 [source,console]
 ....
 $ ./docker-compose up
+....
+
+Mac
+[source,console]
+....
+$ ./docker compose up
 ....
 
 and you should see Encore starting up.
 
 IMPORTANT: By default, there are two folders mapped to your host system by using the example docker-compose file. 
 **/tmp/input and /tmp/output**, which we will refer to as the **inputdir** and the **outputdir**
-_Change these (in the docker-compose file) to something that suits your environment. 
-The default should be fine on mac/linux._
+_Change these (in the docker-compose file) to something that suits your environment if you are not running on Linux. 
+For example /Users/<YOURUSER>/input:/tmp/input should be fine on macos._
 
+====== Get the IP
+
+On Linux:
 - To find the IP Docker-Compose creates (so that you can access Encore's api).
 
 
@@ -70,6 +80,8 @@ $ docker inspect <nameOfDirectoryYouAreRunningFrom>_encorenet
 
 NOTE: By design Docker-compose creates a network called <nameOfDirectoryYouAreRunningFrom>_encorenet
 
+On macos:
+Use 'localhost'
 
 Got the IP? - great! Continue to <<posting-your-first-encorejob>>
 


### PR DESCRIPTION
This PR adds information about how to use Docker Compose or runnable jar to test SVT Encore, and is related to a corresponding PRs in the SVT Encore repository.

The docker compise description have been tested in practice on linux and macos. The jar description on linux